### PR TITLE
Include functional for new stdlib compat

### DIFF
--- a/applications/logtool/logtool.cpp
+++ b/applications/logtool/logtool.cpp
@@ -1,5 +1,6 @@
 #include <iomanip>
 #include <unistd.h>
+#include <functional>
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>


### PR DESCRIPTION
On bionic there was a compile error: `error: 'function' in namespace 'std' does not name a template type` when building `logtool`. This is due to a change in C++ where `<functional>` no longer is included in `<algorithm>`, which was already included before. I've also seen this in compass but believe it's already been fixed there.

@1988kramer could you check this PR on your Mac machine to ensure compatibility and then merge if it works?